### PR TITLE
Add CSS style sheets with @font-face declarations

### DIFF
--- a/webfonts/fanwood.css
+++ b/webfonts/fanwood.css
@@ -1,0 +1,27 @@
+/*
+  'Fanwood'
+  https://www.theleagueofmoveabletype.com/fanwood
+
+  Copyright (c) 2011, Barry Schwartz <site-chieftain@crudfactory.com>,
+  with Reserved Font Name OFL "Fanwood".
+
+  This Font Software is licensed under the SIL Open Font License, Version 1.1.
+  http://scripts.sil.org/OFL
+*/
+@font-face {
+  font-family: 'Fanwood';
+  font-style: normal; /* Roman (Regular) */
+  src: url('fanwood-webfont.eot?#iefix') format('embedded-opentype'),
+       url('fanwood-webfont.woff') format('woff'),
+       url('fanwood-webfont.ttf')  format('truetype'),
+       url('fanwood-webfont.svg#FanwoodRegular') format('svg');
+}
+
+@font-face {
+  font-family: 'Fanwood';
+  font-style: italic;
+  src: url('fanwood_italic-webfont.eot?#iefix') format('embedded-opentype'),
+       url('fanwood_italic-webfont.woff') format('woff'),
+       url('fanwood_italic-webfont.ttf')  format('truetype'),
+       url('fanwood_italic-webfont.svg#FanwoodItalic') format('svg');
+}

--- a/webfonts/fanwood.css
+++ b/webfonts/fanwood.css
@@ -11,7 +11,7 @@
 @font-face {
   font-family: 'Fanwood';
   font-style: normal; /* Roman (Regular) */
-  src: url('fanwood-webfont.eot'),
+  src: url('fanwood-webfont.eot');
   src: url('fanwood-webfont.eot?#iefix') format('embedded-opentype'),
        url('fanwood-webfont.woff') format('woff'),
        url('fanwood-webfont.ttf')  format('truetype'),
@@ -21,7 +21,7 @@
 @font-face {
   font-family: 'Fanwood';
   font-style: italic;
-  src: url('fanwood_italic-webfont.eot'),
+  src: url('fanwood_italic-webfont.eot');
   src: url('fanwood_italic-webfont.eot?#iefix') format('embedded-opentype'),
        url('fanwood_italic-webfont.woff') format('woff'),
        url('fanwood_italic-webfont.ttf')  format('truetype'),

--- a/webfonts/fanwood.css
+++ b/webfonts/fanwood.css
@@ -11,6 +11,7 @@
 @font-face {
   font-family: 'Fanwood';
   font-style: normal; /* Roman (Regular) */
+  src: url('fanwood-webfont.eot'),
   src: url('fanwood-webfont.eot?#iefix') format('embedded-opentype'),
        url('fanwood-webfont.woff') format('woff'),
        url('fanwood-webfont.ttf')  format('truetype'),
@@ -20,6 +21,7 @@
 @font-face {
   font-family: 'Fanwood';
   font-style: italic;
+  src: url('fanwood_italic-webfont.eot'),
   src: url('fanwood_italic-webfont.eot?#iefix') format('embedded-opentype'),
        url('fanwood_italic-webfont.woff') format('woff'),
        url('fanwood_italic-webfont.ttf')  format('truetype'),

--- a/webfonts/fanwood_text.css
+++ b/webfonts/fanwood_text.css
@@ -1,0 +1,27 @@
+/*
+  'Fanwood Text' (slightly darker and reduced in contrast)
+  https://www.theleagueofmoveabletype.com/fanwood
+
+  Copyright (c) 2011, Barry Schwartz <site-chieftain@crudfactory.com>,
+  with Reserved Font Name OFL "Fanwood".
+
+  This Font Software is licensed under the SIL Open Font License, Version 1.1.
+  http://scripts.sil.org/OFL
+*/
+@font-face {
+  font-family: 'Fanwood Text';
+  font-style: normal; /* Roman (Regular) */
+  src: url('fanwood_text-webfont.eot?#iefix') format('embedded-opentype'),
+       url('fanwood_text-webfont.woff') format('woff'),
+       url('fanwood_text-webfont.ttf')  format('truetype'),
+       url('fanwood_text-webfont.svg#FanwoodTextRegular') format('svg');
+}
+
+@font-face {
+  font-family: 'Fanwood Text';
+  font-style: italic;
+  src: url('fanwood_text_italic-webfont.eot?#iefix') format('embedded-opentype'),
+       url('fanwood_text_italic-webfont.woff') format('woff'),
+       url('fanwood_text_italic-webfont.ttf')  format('truetype'),
+       url('fanwood_text_italic-webfont.svg#FanwoodTextItalic') format('svg');
+}

--- a/webfonts/fanwood_text.css
+++ b/webfonts/fanwood_text.css
@@ -11,7 +11,7 @@
 @font-face {
   font-family: 'Fanwood Text';
   font-style: normal; /* Roman (Regular) */
-  src: url('fanwood_text-webfont.eot'),
+  src: url('fanwood_text-webfont.eot');
   src: url('fanwood_text-webfont.eot?#iefix') format('embedded-opentype'),
        url('fanwood_text-webfont.woff') format('woff'),
        url('fanwood_text-webfont.ttf')  format('truetype'),
@@ -21,7 +21,7 @@
 @font-face {
   font-family: 'Fanwood Text';
   font-style: italic;
-  src: url('fanwood_text_italic-webfont.eot'),
+  src: url('fanwood_text_italic-webfont.eot');
   src: url('fanwood_text_italic-webfont.eot?#iefix') format('embedded-opentype'),
        url('fanwood_text_italic-webfont.woff') format('woff'),
        url('fanwood_text_italic-webfont.ttf')  format('truetype'),

--- a/webfonts/fanwood_text.css
+++ b/webfonts/fanwood_text.css
@@ -11,6 +11,7 @@
 @font-face {
   font-family: 'Fanwood Text';
   font-style: normal; /* Roman (Regular) */
+  src: url('fanwood_text-webfont.eot'),
   src: url('fanwood_text-webfont.eot?#iefix') format('embedded-opentype'),
        url('fanwood_text-webfont.woff') format('woff'),
        url('fanwood_text-webfont.ttf')  format('truetype'),
@@ -20,6 +21,7 @@
 @font-face {
   font-family: 'Fanwood Text';
   font-style: italic;
+  src: url('fanwood_text_italic-webfont.eot'),
   src: url('fanwood_text_italic-webfont.eot?#iefix') format('embedded-opentype'),
        url('fanwood_text_italic-webfont.woff') format('woff'),
        url('fanwood_text_italic-webfont.ttf')  format('truetype'),


### PR DESCRIPTION
The format used for the @font-face declarations is the
"Fontspring @Font-Face Syntax"[1] considered [2]
"the most simple and compatible one".

[1] The New Bulletproof @Font-Face Syntax
2011-02-03 (last updated: 2011-04-21)
http://www.fontspring.com/blog/the-new-bulletproof-font-face-syntax

[2] The @Font-Face Rule And Useful Web Font Tricks
2011-03-02, by Ralf Hermann
http://www.smashingmagazine.com/2011/03/02/the-font-face-rule-revisited-and-useful-tricks/
